### PR TITLE
fixed the docker error that made /vendor not load in containers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "yourname/bulk-sms-app",
+  "require": {
+    "africastalking/africastalking": "^3.0"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,14 @@ services:
     build: .
     container_name: bulk-sms-app
     ports:
-      - "8090:8090"
+      - "8090:80"
     volumes:
-      - .:/var/www/html
+      # Mount only specific files/directories instead of entire project
+      - ./index.html:/var/www/html/index.html
+      - ./send_sms.php:/var/www/html/send_sms.php
+      - ./db.php:/var/www/html/db.php
+      - ./.env:/var/www/html/.env
+      # Don't mount vendor/ - let it stay from the Docker build
     depends_on:
       - db
 


### PR DESCRIPTION
This pull request includes updates to the Docker setup, dependency management, and the `docker-compose.yml` configuration for a PHP-based bulk SMS application. The changes aim to optimize the Docker build process, improve dependency handling, and refine the container's file mounting strategy.

### Docker setup improvements:
* Updated the `Dockerfile` to cache dependencies during builds by copying `composer.json` and `composer.lock` first, installing dependencies with Composer, and then copying the rest of the application files. This reduces build times for subsequent builds.
* Added Composer installation directly in the `Dockerfile` and exposed port 80 for the application.

### Dependency management:
* Added a `composer.json` file to explicitly define the application's name and required dependencies, including the Africa's Talking SDK (`africastalking/africastalking`).

### `docker-compose.yml` configuration refinement:
* Changed the exposed port mapping from `8090:8090` to `8090:80` to align with the Apache configuration in the container.
* Updated file mounting to include only specific files (`index.html`, `send_sms.php`, `db.php`, `.env`) instead of the entire project directory, ensuring the `vendor/` directory remains untouched from the Docker build.