### PR TITLE
fetch_messages from database

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -37,6 +37,9 @@ function initializeApp() {
     document.getElementById('reportFilter').addEventListener('change', function() {
         filterReports(this.value);
     });
+
+    // 🔽 Add this at the very end:
+    loadReportsFromServer();
 }
 
 // Switch between tabs
@@ -311,6 +314,39 @@ function validatePhoneNumber(phone) {
     const phoneRegex = /^\+[1-9]\d{1,14}$/;
     return phoneRegex.test(phone);
 }
+
+function loadReportsFromServer() {
+    fetch('fetch_reports.php')
+        .then(res => res.json())
+        .then(data => {
+            if (!data.success) {
+                console.error("Failed to fetch reports:", data.error);
+                return;
+            }
+
+            const tbody = document.getElementById('reportsTableBody');
+            tbody.innerHTML = ''; // Clear existing rows
+
+            data.data.forEach(row => {
+                const statusClass = {
+                    sent: 'status-sent',
+                    failed: 'status-failed',
+                    pending: 'status-pending'
+                }[row.status.toLowerCase()] || '';
+
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${row.created_at}</td>
+                    <td>${row.recipients}</td>
+                    <td><span class="status-badge ${statusClass}">${row.status}</span></td>
+                    <td>${row.message}</td>
+                `;
+                tbody.appendChild(tr);
+            });
+        })
+        .catch(err => console.error('Error fetching report data:', err));
+}
+
 
 // Export functions for testing or external use
 window.BulkSMS = {

--- a/dashboard.html
+++ b/dashboard.html
@@ -106,24 +106,6 @@
                     </thead>
                     <tbody id="reportsTableBody">
                         <!-- Sample data - replace with dynamic content -->
-                        <tr>
-                            <td>2024-01-15 14:30</td>
-                            <td>5</td>
-                            <td><span class="status-badge status-sent">Sent</span></td>
-                            <td>Welcome to our service!</td>
-                        </tr>
-                        <tr>
-                            <td>2024-01-15 10:15</td>
-                            <td>3</td>
-                            <td><span class="status-badge status-failed">Failed</span></td>
-                            <td>Reminder: Meeting tomorrow</td>
-                        </tr>
-                        <tr>
-                            <td>2024-01-14 16:45</td>
-                            <td>8</td>
-                            <td><span class="status-badge status-pending">Pending</span></td>
-                            <td>Thank you for your order</td>
-                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/fetch_reports.php
+++ b/fetch_reports.php
@@ -1,0 +1,26 @@
+<?php
+header('Content-Type: application/json');
+
+// Include the DB connection
+require_once 'db.php';
+
+try {
+    $stmt = $pdo->query("
+        SELECT 
+            created_at, 
+            COUNT(phone) AS recipients, 
+            status, 
+            message 
+        FROM messages 
+        GROUP BY message, created_at, status 
+        ORDER BY created_at DESC 
+        LIMIT 100
+    ");
+
+    $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode(['success' => true, 'data' => $results]);
+} catch (PDOException $e) {
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
This pull request introduces functionality to dynamically fetch and display SMS reports on the dashboard. It includes changes to the front-end JavaScript, HTML structure, and the addition of a new back-end PHP endpoint. Below are the most important changes grouped by theme:

### Front-End Enhancements:
* Added a new `loadReportsFromServer` function in `assets/js/dashboard.js` to fetch report data from the server and dynamically populate the reports table. The function handles API response parsing, error handling, and DOM updates.
* Updated the `initializeApp` function in `assets/js/dashboard.js` to call `loadReportsFromServer` on app initialization.

### HTML Updates:
* Removed hardcoded sample report rows from the `<tbody>` in `dashboard.html`, preparing the table for dynamic content insertion.

### Back-End API Addition:
* Introduced a new `fetch_reports.php` endpoint to query the database for SMS report data. The endpoint returns a JSON response with report details, including creation time, recipient count, status, and message content. It includes error handling for database issues.